### PR TITLE
refactor: 토큰 검증을 할 때 사용자 조회 쿼리 최적화

### DIFF
--- a/src/main/java/com/groom/orbit/config/security/domain/MemberDetails.java
+++ b/src/main/java/com/groom/orbit/config/security/domain/MemberDetails.java
@@ -7,13 +7,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import com.groom.orbit.member.dao.jpa.entity.Member;
+import com.groom.orbit.auth.dao.entity.AuthMember;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class MemberDetails implements UserDetails {
-  private final Member member;
+  private final AuthMember member;
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/groom/orbit/config/security/service/MemberDetailService.java
+++ b/src/main/java/com/groom/orbit/config/security/service/MemberDetailService.java
@@ -6,11 +6,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groom.orbit.auth.dao.AuthMemberRepository;
+import com.groom.orbit.auth.dao.entity.AuthMember;
 import com.groom.orbit.common.exception.CommonException;
 import com.groom.orbit.common.exception.ErrorCode;
 import com.groom.orbit.config.security.domain.MemberDetails;
-import com.groom.orbit.member.dao.jpa.MemberRepository;
-import com.groom.orbit.member.dao.jpa.entity.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,13 +19,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberDetailService implements UserDetailsService {
 
-  private final MemberRepository memberRepository;
+  //  private final MemberRepository memberRepository;
+  private final AuthMemberRepository authMemberRepository;
 
   @Override
-  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    Member member =
-        memberRepository
-            .findById(Long.parseLong(username))
+  public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+    AuthMember member =
+        authMemberRepository
+            .findById(Long.parseLong(userId))
             .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_MEMBER));
 
     return new MemberDetails(member);


### PR DESCRIPTION
AuthMember를 이용해 text 속성 컬럼을 조회하지 않도록 하여 쿼리문을 최적화했습니다.

🚀 개요
close #162 
🔍 변경사항
변경사항 1
변경사항 2
변경사항 3
⏳ 작업 내용
 작업 내용 1
 작업 내용 2
 작업 내용 3
📝 논의사항